### PR TITLE
Fix permissions for service account after upgrades

### DIFF
--- a/Source/Applications/PDQTracker/PDQTrackerSetup/CustomFeatureTree.wxs
+++ b/Source/Applications/PDQTracker/PDQTrackerSetup/CustomFeatureTree.wxs
@@ -16,10 +16,6 @@ Maintenance dialog sequence:
  - WixUI_MaintenanceTypeDlg
  - WixUI_CustomizeDlg
  - WixUI_VerifyReadyDlg
-
-Patch dialog sequence:
- - WixUI_WelcomeDlg
- - WixUI_VerifyReadyDlg
 -->
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
@@ -44,7 +40,6 @@ Patch dialog sequence:
       <Publish Dialog="CustomExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
 
       <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg">NOT Installed</Publish>
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
 
       <Publish Dialog="LicenseAgreementDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="CustomizeDlg">LicenseAccepted = "1"</Publish>
@@ -54,8 +49,7 @@ Patch dialog sequence:
       <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
 
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg" Order="1">NOT Installed OR WixUI_InstallMode = "Change"</Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="3">Installed AND PATCH</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT(WixUI_InstallMode = "Change")</Publish>
 
       <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
 

--- a/Source/Applications/PDQTracker/PDQTrackerSetup/PDQTrackerSetup.wxs
+++ b/Source/Applications/PDQTracker/PDQTrackerSetup/PDQTrackerSetup.wxs
@@ -101,10 +101,22 @@
       <UIRef Id="WixUI_ErrorProgressText" />
       <DialogRef Id="CompanyInfoDialog" />
       <DialogRef Id="ServiceAccountDialog" />
-      <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="ServiceAccountDialog"><![CDATA[&PDQTrackerFeature=3]]></Publish>
-      <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg"><![CDATA[NOT(&PDQTrackerFeature=3)]]></Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CompanyInfoDialog">(NOT Installed OR WixUI_InstallMode = "Change") AND <![CDATA[&PDQTrackerFeature=3]]></Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg">(NOT Installed OR WixUI_InstallMode = "Change") AND <![CDATA[NOT(&PDQTrackerFeature=3)]]></Publish>
+
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLSERVICEFEATURE" Value="1" Order="7"><![CDATA[&PDQTrackerFeature=3 OR (!PDQTrackerFeature=3 AND &PDQTrackerFeature=-1)]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLSERVICEFEATURE" Order="7"><![CDATA[NOT(&PDQTrackerFeature=3 OR (!PDQTrackerFeature=3 AND &PDQTrackerFeature=-1))]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLMANAGERFEATURE" Value="1" Order="7"><![CDATA[&PDQTrackerManagerFeature=3 OR (!PDQTrackerManagerFeature=3 AND &PDQTrackerManagerFeature=-1)]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLMANAGERFEATURE" Order="7"><![CDATA[NOT(&PDQTrackerManagerFeature=3 OR (!PDQTrackerManagerFeature=3 AND &PDQTrackerManagerFeature=-1))]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLCONSOLEFEATURE" Value="1" Order="7"><![CDATA[&PDQTrackerConsoleFeature=3 OR (!PDQTrackerConsoleFeature=3 AND &PDQTrackerConsoleFeature=-1)]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLCONSOLEFEATURE" Order="7"><![CDATA[NOT(&PDQTrackerConsoleFeature=3 OR (!PDQTrackerConsoleFeature=3 AND &PDQTrackerConsoleFeature=-1))]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLTOOLSFEATURE" Value="1" Order="7"><![CDATA[&PDQTrackerToolsFeature=3 OR (!PDQTrackerToolsFeature=3 AND &PDQTrackerToolsFeature=-1)]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLTOOLSFEATURE" Order="7"><![CDATA[NOT(&PDQTrackerToolsFeature=3 OR (!PDQTrackerToolsFeature=3 AND &PDQTrackerToolsFeature=-1))]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLOPTIONALFEATURE" Value="1" Order="7"><![CDATA[&PDQTrackerOptionalFeatures=3 OR (!PDQTrackerOptionalFeatures=3 AND &PDQTrackerOptionalFeatures=-1)]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLOPTIONALFEATURE" Order="7"><![CDATA[NOT(&PDQTrackerOptionalFeatures=3 OR (!PDQTrackerOptionalFeatures=3 AND &PDQTrackerOptionalFeatures=-1))]]></Publish>
+
+      <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="ServiceAccountDialog" Order="8">INSTALLSERVICEFEATURE</Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="8">NOT(INSTALLSERVICEFEATURE)</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CompanyInfoDialog">INSTALLSERVICEFEATURE</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg">NOT(INSTALLSERVICEFEATURE)</Publish>
       <Publish Dialog="CustomExitDialog" Control="Finish" Event="DoAction" Value="StartCSUProcessAction">WIXUI_CUSTOMEXITDIALOGOPTIONALCHECKBOX = 1</Publish>
     </UI>
 
@@ -123,6 +135,12 @@
     <Icon Id="APPPDCImporter.ico.exe" SourceFile="$(var.ProjectDir)\APPPDCImporter.exe"/>
     <Icon Id="SELPDCImporter.ico.exe" SourceFile="$(var.ProjectDir)\SELPDCImporter.exe"/>
 
+    <Property Id="INSTALLSERVICEFEATURE" Secure="yes" />
+    <Property Id="INSTALLMANAGERFEATURE" Secure="yes" />
+    <Property Id="INSTALLCONSOLEFEATURE" Secure="yes" />
+    <Property Id="INSTALLTOOLSFEATURE" Secure="yes" />
+    <Property Id="INSTALLOPTIONALFEATURE" Secure="yes" />
+
     <Property Id="SERVICENAME" Value="$(var.PDQTracker.TargetName)" />
     <Property Id="SERVICEPASSWORD" Hidden="yes" />
     <Property Id="HTTPSERVICEPORTS" Value="6059,6060,6159,6160,6360,6460,5022" />
@@ -135,11 +153,24 @@
     <Property Id="REGSERVICESTARTVALUE">
       <RegistrySearch Id="ServiceStartRegSearch" Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\[SERVICENAME]" Name="Start" Type="raw" />
     </Property>
+
     <SetProperty Action="SetServiceStartDefault" Id="SERVICESTART" After="AppSearch" Value="#2" Sequence="first"><![CDATA[NOT REGSERVICESTARTVALUE]]></SetProperty>
     <SetProperty Action="SetServiceStartRegistry" Id="SERVICESTART" After="AppSearch" Value="[REGSERVICESTARTVALUE]" Sequence="first"><![CDATA[REGSERVICESTARTVALUE]]></SetProperty>
     <SetProperty Action="SetServiceAccountDefault" Id="SERVICEACCOUNT" After="AppSearch" Value="NT SERVICE\[SERVICENAME]" Sequence="first"><![CDATA[NOT REGSERVICEACCOUNT]]></SetProperty>
     <SetProperty Action="SetServiceAccountRegistry" Id="SERVICEACCOUNT" After="AppSearch" Value="[REGSERVICEACCOUNT]" Sequence="first"><![CDATA[REGSERVICEACCOUNT]]></SetProperty>
     <SetProperty Id="PROCESSSTARTINFO" Value="FileName={[#ConfigurationSetupUtility.exe]};Arguments=-install;UseShellExecute=True;Verb=runas" After="ExecuteAction" Sequence="ui" />
+
+    <SetProperty Action="INSTALLSERVICEFEATURE0" Id="INSTALLSERVICEFEATURE" Value="1" After="CostFinalize" Sequence="both"><![CDATA[&PDQTrackerFeature=3 OR (!PDQTrackerFeature=3 AND &PDQTrackerFeature=-1)]]></SetProperty>
+    <SetProperty Action="INSTALLSERVICEFEATURE1" Id="INSTALLSERVICEFEATURE" Value="" After="CostFinalize" Sequence="both"><![CDATA[NOT(&PDQTrackerFeature=3 OR (!PDQTrackerFeature=3 AND &PDQTrackerFeature=-1))]]></SetProperty>
+    <SetProperty Action="INSTALLMANAGERFEATURE0" Id="INSTALLMANAGERFEATURE" Value="1" After="CostFinalize" Sequence="both"><![CDATA[&PDQTrackerManagerFeature=3 OR (!PDQTrackerManagerFeature=3 AND &PDQTrackerManagerFeature=-1)]]></SetProperty>
+    <SetProperty Action="INSTALLMANAGERFEATURE1" Id="INSTALLMANAGERFEATURE" Value="" After="CostFinalize" Sequence="both"><![CDATA[NOT(&PDQTrackerManagerFeature=3 OR (!PDQTrackerManagerFeature=3 AND &PDQTrackerManagerFeature=-1))]]></SetProperty>
+    <SetProperty Action="INSTALLCONSOLEFEATURE0" Id="INSTALLCONSOLEFEATURE" Value="1" After="CostFinalize" Sequence="both"><![CDATA[&PDQTrackerConsoleFeature=3 OR (!PDQTrackerConsoleFeature=3 AND &PDQTrackerConsoleFeature=-1)]]></SetProperty>
+    <SetProperty Action="INSTALLCONSOLEFEATURE1" Id="INSTALLCONSOLEFEATURE" Value="" After="CostFinalize" Sequence="both"><![CDATA[NOT(&PDQTrackerConsoleFeature=3 OR (!PDQTrackerConsoleFeature=3 AND &PDQTrackerConsoleFeature=-1))]]></SetProperty>
+    <SetProperty Action="INSTALLTOOLSFEATURE0" Id="INSTALLTOOLSFEATURE" Value="1" After="CostFinalize" Sequence="both"><![CDATA[&PDQTrackerToolsFeature=3 OR (!PDQTrackerToolsFeature=3 AND &PDQTrackerToolsFeature=-1)]]></SetProperty>
+    <SetProperty Action="INSTALLTOOLSFEATURE1" Id="INSTALLTOOLSFEATURE" Value="" After="CostFinalize" Sequence="both"><![CDATA[NOT(&PDQTrackerToolsFeature=3 OR (!PDQTrackerToolsFeature=3 AND &PDQTrackerToolsFeature=-1))]]></SetProperty>
+    <SetProperty Action="INSTALLOPTIONALFEATURE0" Id="INSTALLOPTIONALFEATURE" Value="1" After="CostFinalize" Sequence="both"><![CDATA[&PDQTrackerOptionalFeatures=3 OR (!PDQTrackerOptionalFeatures=3 AND &PDQTrackerOptionalFeatures=-1)]]></SetProperty>
+    <SetProperty Action="INSTALLOPTIONALFEATURE1" Id="INSTALLOPTIONALFEATURE" Value="" After="CostFinalize" Sequence="both"><![CDATA[NOT(&PDQTrackerOptionalFeatures=3 OR (!PDQTrackerOptionalFeatures=3 AND &PDQTrackerOptionalFeatures=-1))]]></SetProperty>
+
     <WixVariable Id="WixUIBannerBmp" Value="$(var.ProjectDir)\PDQTrackerSetupBanner.bmp" />
     <WixVariable Id="WixUIDialogBmp" Value="$(var.ProjectDir)\PDQTrackerSetupDialog.bmp" />
     <WixVariable Id="WixUILicenseRtf" Value="$(var.ProjectDir)\INSTALL_LICENSE.rtf" />
@@ -170,12 +201,12 @@
     </UI>
 
     <InstallExecuteSequence>
-      <Custom Action="CompanyInfoAction.SetProperty" After="InstallFiles">NOT REMOVE AND <![CDATA[&PDQTrackerFeature=3]]></Custom>
-      <Custom Action="CompanyInfoAction" After="CompanyInfoAction.SetProperty">NOT REMOVE AND <![CDATA[&PDQTrackerFeature=3]]></Custom>
-      <Custom Action="ConfigureServiceAction.SetProperty" After="InstallServices">NOT REMOVE AND <![CDATA[&PDQTrackerFeature=3]]></Custom>
-      <Custom Action="ConfigureServiceAction" After="ConfigureServiceAction.SetProperty">NOT REMOVE AND <![CDATA[&PDQTrackerFeature=3]]></Custom>
-      <Custom Action="ServiceAccountAction.SetProperty" After="ConfigureServiceAction">NOT REMOVE</Custom>
-      <Custom Action="ServiceAccountAction" After="ServiceAccountAction.SetProperty">NOT REMOVE</Custom>
+      <Custom Action="CompanyInfoAction.SetProperty" After="InstallFiles">INSTALLSERVICEFEATURE</Custom>
+      <Custom Action="CompanyInfoAction" After="CompanyInfoAction.SetProperty">INSTALLSERVICEFEATURE</Custom>
+      <Custom Action="ConfigureServiceAction.SetProperty" After="InstallServices"><![CDATA[&PDQTrackerFeature=3]]></Custom>
+      <Custom Action="ConfigureServiceAction" After="ConfigureServiceAction.SetProperty"><![CDATA[&PDQTrackerFeature=3]]></Custom>
+      <Custom Action="ServiceAccountAction.SetProperty" After="ConfigureServiceAction">INSTALLSERVICEFEATURE</Custom>
+      <Custom Action="ServiceAccountAction" After="ServiceAccountAction.SetProperty">INSTALLSERVICEFEATURE</Custom>
       <Custom Action="NetFxExecuteNativeImageCommitInstall" After="NetFxExecuteNativeImageUninstall">0</Custom>
       <Custom Action="NetFxExecuteNativeImageInstall" After="NetFxExecuteNativeImageCommitInstall" />
       <!-- Set write registry values sequence after service install but before service start to restore original service start mode -->

--- a/Source/Applications/PDQTracker/PDQTrackerSetup/PDQTrackerSetup.wxs
+++ b/Source/Applications/PDQTracker/PDQTrackerSetup/PDQTrackerSetup.wxs
@@ -142,6 +142,7 @@
     <Property Id="INSTALLOPTIONALFEATURE" Secure="yes" />
 
     <Property Id="SERVICENAME" Value="$(var.PDQTracker.TargetName)" />
+    <Property Id="SERVICEACCOUNT" Secure="yes" />
     <Property Id="SERVICEPASSWORD" Hidden="yes" />
     <Property Id="HTTPSERVICEPORTS" Value="6059,6060,6159,6160,6360,6460,5022" />
     <Property Id="COMPANYNAME" Value="Grid Protection Alliance" />


### PR DESCRIPTION
The service account loses permissions to start and stop the service after using the installer to upgrade the system. This PR fixes that by running `ServiceAccountAction` so long as the service is still installed.